### PR TITLE
Fix is_short logic

### DIFF
--- a/perl/Wengan/Reads.pm
+++ b/perl/Wengan/Reads.pm
@@ -152,11 +152,7 @@ sub _guess_read_length{
 
 sub is_short{
     my $self=shift;
-    if(defined $self->{sreads}){
-        return 1;
-    }else{
-      return 0;
-    }
+    return scalar(@{$self->{sreads}}) > 0 ? 1 : 0;
 }
 
 sub get_read_length{

--- a/t/reads.t
+++ b/t/reads.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/../perl";
+use Wengan::Reads;
+
+# create temporary directory for data
+my $tmpdir = "$FindBin::Bin/tmp";
+mkdir $tmpdir unless -d $tmpdir;
+
+# create two small FASTQ files and gzip them
+my $fq1 = "$tmpdir/s1.fq";
+my $fq2 = "$tmpdir/s2.fq";
+open my $fh, '>', $fq1 or die $!;
+print $fh "\@r1\nACGT\n+\n!!!!\n";
+close $fh;
+open $fh, '>', $fq2 or die $!;
+print $fh "\@r2\nTGCA\n+\n!!!!\n";
+close $fh;
+
+system('gzip','-f',$fq1) == 0 or die "gzip failed";
+system('gzip','-f',$fq2) == 0 or die "gzip failed";
+
+$fq1 .= '.gz';
+$fq2 .= '.gz';
+
+my $reads = Wengan::Reads->new();
+ok(!$reads->is_short, 'new object has no short reads');
+
+$reads->add_short_reads("$fq1,$fq2");
+
+ok($reads->is_short, 'short reads detected after add_short_reads');
+
+is($reads->get_read_length, 5, 'read length detected correctly');
+
+unlink $fq1;
+unlink $fq2;
+rmdir $tmpdir;
+
+done_testing();


### PR DESCRIPTION
## Summary
- correct detection of short read availability
- add regression test for Reads.pm

## Testing
- `prove -v t/reads.t`

------
https://chatgpt.com/codex/tasks/task_e_6848f99f74f0832e85372a48898e8616