### PR TITLE
Fix typos, bug, and add test

### DIFF
--- a/perl/Wengan/Chimeric/IM.pm
+++ b/perl/Wengan/Chimeric/IM.pm
@@ -106,7 +106,7 @@ sub _create_coveragefile_jobs{
   my $target=$contigs;
   $target=~s/.fa/.cov.txt/;
   push(@{$job->{target}},$target);
-  my $cmd='grep ">" '.$contigs.' | sed \'s/>//\' | awk \'{print $$1" "$$2}\' | sed \'s/>//g\' > '.$target;
+  my $cmd='grep ">" '.$contigs.' | sed \'s/>//\' | awk \'{print $1" "$2}\' | sed \'s/>//g\' > '.$target;
   push(@{$job->{cmds}},$cmd);
   push(@{$self->{jobs}},$job);
 }

--- a/perl/Wengan/Common/GlobalConfig.pm
+++ b/perl/Wengan/Common/GlobalConfig.pm
@@ -32,7 +32,7 @@ DiscoVarDenovo is a high memory short-read assembler that exploit the pair-end i
 
 =item * FastMin-SG
 
-Fastmin-SG is an ultrafast alignment-free algorihtm for pseudo-alignment fo pair-end reads from short or long-reads.
+Fastmin-SG is an ultrafast alignment-free algorithm for pseudo-alignment for pair-end reads from short or long reads.
 
 =item * IntervalMiss
 

--- a/t/fml.t
+++ b/t/fml.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/../perl";
+use Wengan::Mapper::FML;
+
+my $fml = Wengan::Mapper::FML->new(x => 'pacraw');
+my $sizes = $fml->_get_inserts_sizes('');
+my $expected = [qw(500 1000 2000 3000 4000 5000 6000 7000 8000 10000 15000 20000)];
+is_deeply($sizes, $expected, 'default pacraw insert sizes');
+
+done_testing();

--- a/wengan.pl
+++ b/wengan.pl
@@ -354,8 +354,8 @@ IntervalMiss detect miss-assembled contigs and correct them when necessary.
 
 =head2  Liger
 
-Liger use the Synthetic Scaffoding Graph to compute overlap among long reads,
-order and orient short contigs, validate scaffols sequences, fill the gaps and
+Liger use the Synthetic Scaffolding Graph to compute overlap among long reads,
+order and orient short contigs, validate scaffold sequences, fill the gaps and
 polishing of the assembly.
 
 =head3 Liger options


### PR DESCRIPTION
## Summary
- fix spelling mistakes in GlobalConfig
- fix awk command in IM coverage generation
- correct documentation of Liger options
- test default insert size list for FML

## Testing
- `prove -lr t`

------
https://chatgpt.com/codex/tasks/task_e_6848f970f718832e8f8c25c7aaa564bc